### PR TITLE
Fix 404 error due to missing folder path

### DIFF
--- a/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 3/Examples/linear.html
+++ b/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 3/Examples/linear.html
@@ -3,7 +3,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@latest"> </script>   
 <script>
     async function run(){
-        const MODEL_URL = 'http://127.0.0.1:8887/model.json';
+        const MODEL_URL = 'http://127.0.0.1:8887/Examples/model.json';
         const model = await tf.loadLayersModel(MODEL_URL);
         console.log(model.summary());
         const input = tf.tensor2d([10.0], [1,1]);


### PR DESCRIPTION
Original model_url gave 404 error as below 
<img width="1675" alt="error404_model_json" src="https://user-images.githubusercontent.com/35646492/70787904-b2e25c80-1dca-11ea-921d-59548304ca4b.png">

After amending linear.html file by adding in the folder path, it can now load without error
<img width="1678" alt="fix_url_model_json" src="https://user-images.githubusercontent.com/35646492/70787993-dc9b8380-1dca-11ea-82ac-7f4431050c10.png">
