### PR TITLE
Change logs.get('accuracy') to logs.get('acc')

### DIFF
--- a/Exercises/Exercise 2 - Handwriting Recognition/Exercise2-Answer.ipynb
+++ b/Exercises/Exercise 2 - Handwriting Recognition/Exercise2-Answer.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "class myCallback(tf.keras.callbacks.Callback):\n",
         "  def on_epoch_end(self, epoch, logs={}):\n",
-        "    if(logs.get('accuracy')>0.99):\n",
+        "    if(logs.get('acc')>0.99):\n",
         "      print(\"\\nReached 99% accuracy so cancelling training!\")\n",
         "      self.model.stop_training = True\n",
         "\n",


### PR DESCRIPTION
logs.get('acc') raises error 
Due to documentation (https://keras.io/callbacks/) it should be 'acc', not 'accuracy'