### PR TITLE
Changing from 'acc' to 'accuracy' in plot_graphs

### DIFF
--- a/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Answer.ipynb
+++ b/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Answer.ipynb
@@ -327,7 +327,7 @@
         "  plt.legend([string, 'val_'+string])\n",
         "  plt.show()\n",
         "  \n",
-        "plot_graphs(history, \"acc\")\n",
+        "plot_graphs(history, \"accuracy\")\n",
         "plot_graphs(history, \"loss\")"
       ]
     },


### PR DESCRIPTION
An error is thrown when trying to plot the accuracy of the model's training, because 'acc' is used as the metric instead of 'accuracy' 