### PR TITLE
tfvis.show.fitCallbacks expects 'acc' and 'val_acc' as metrics .

### DIFF
--- a/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 2/Examples/script.js
+++ b/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 2/Examples/script.js
@@ -21,7 +21,7 @@ function getModel() {
 }
 
 async function train(model, data) {
-	const metrics = ['loss', 'val_loss', 'accuracy', 'val_accuracy'];
+	const metrics = ['loss', 'val_loss', 'acc', 'val_acc'];
 	const container = { name: 'Model Training', styles: { height: '640px' } };
 	const fitCallbacks = tfvis.show.fitCallbacks(container, metrics);
   


### PR DESCRIPTION
tfvis.show.fitCallbacks expects 'acc' and 'val_acc' as metrics . If you use 'accuracy' and 'val_accuracy', they don't show up in the visualization.