### PR TITLE
Correction for classification probability

### DIFF
--- a/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
+++ b/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
@@ -386,7 +386,7 @@
         "\n",
         "The output of the model is a list of 10 numbers. These numbers are a probability that the value being classified is the corresponding value, i.e. the first value in the list is the probability that the handwriting is of a '0', the next is a '1' etc. Notice that they are all VERY LOW probabilities.\n",
         "\n",
-        "For the 7, the probability was .999+, i.e. the neural network is telling us that it's almost certainly a 7."
+        "For the 9, the probability was .96+, i.e. the neural network is telling us that it's almost certainly a 9."
       ]
     },
     {


### PR DESCRIPTION
The question in this classification probability (`classification[0]`) has `test_labels[0]` as a 9.
But the answer said the probability for 7.