### PR TITLE
Fix bug occuring in Firefox

### DIFF
--- a/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 4/Exercise/webcam.js
+++ b/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 4/Exercise/webcam.js
@@ -43,9 +43,13 @@ class Webcam {
       // Crop the image so we're using the center square of the rectangular
       // webcam.
       const croppedImage = this.cropImage(reversedImage);
+      
+      // Ensure that Tensor has the right size
+      const size = Math.min(this.webcamElement.height, this.webcamElement.width);
+      const resizeImage = tf.image.resizeBilinear(croppedImage, [size, size]);
 
       // Expand the outer most dimension so we have a batch size of 1.
-      const batchedImage = croppedImage.expandDims(0);
+      const batchedImage = resizeImage.expandDims(0);
 
       // Normalize the image between -1 and 1. The image comes in between 0-255,
       // so we divide by 127 and subtract 1.


### PR DESCRIPTION
In Firefox the function tf.browser.fromPixels(this.webcamElement) doesn't return a Tensor that matches the video width and height.
The croppedImage obtained is thus of size [240, 240] which raises the follwing error:
Error: Error when checking : expected input_1 to have shape [null,224,224,3] but got array with shape [1,240,240,3].

In order to match the input size of the model the croppedImage needs to be resized. This is ensured by the two lines added.

The fix has been tested on Firefox Browser 74.0.1 (64 bits) and Google Chrome 80.0.3987.163 (64 bits)