### PR TITLE
Propose to evaluate label_tokenizer word_index

### DIFF
--- a/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Question.ipynb
+++ b/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Question.ipynb
@@ -218,6 +218,8 @@
         "training_label_seq = # YOUR CODE HERE\n",
         "validation_label_seq = # YOUR CODE HERE\n",
         "\n",
+        "print(label_tokenizer.word_index)\n"
+        "\n",
         "print(training_label_seq[0])\n",
         "print(training_label_seq[1])\n",
         "print(training_label_seq[2])\n",
@@ -229,6 +231,7 @@
         "print(validation_label_seq.shape)\n",
         "\n",
         "# Expected output\n",
+        "# {'sport': 1, 'business': 2, 'politics': 3, 'entertainment': 4, 'tech': 5}\n",
         "# [4]\n",
         "# [2]\n",
         "# [1]\n",


### PR DESCRIPTION
Add `print(label_tokenizer.word_index)` and its expected output, to evaluate the content of label_tokenizer,
just to make sure that the students did not add `oov_token` while constructing label_tokenizer.