### PR TITLE
Fixed typo in documentation

### DIFF
--- a/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
+++ b/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
@@ -52,7 +52,7 @@
       },
       "source": [
         "# Beyond Hello World, A Computer Vision Example\n",
-        "In the previous exercise you saw how to create a neural network that figured out the problem you were trying to solve. This gave an explicit example of learned behavior. Of course, in that instance, it was a bit of overkill because it would have been easier to write the function Y=2x-1 directly, instead of bothering with using Machine Learning to learn the relationship between X and Y for a fixed set of values, and extending that for all values.\n",
+        "In the previous exercise you saw how to create a neural network that figured out the problem you were trying to solve. This gave an explicit example of learned behavior. Of course, in that instance, it was a bit of overkill because it would have been easier to write the function Y=2X-1 directly, instead of bothering with using Machine Learning to learn the relationship between X and Y for a fixed set of values, and extending that for all values.\n",
         "\n",
         "But what about a scenario where writing rules like that is much more difficult -- for example a computer vision problem? Let's take a look at a scenario where we can recognize different items of clothing, trained from a dataset containing 10 different types."
       ]


### PR DESCRIPTION
The variable x in the equation is replaced by X as it is being mentioned in the statement following the equation.