### PR TITLE
Corrected mistake

### DIFF
--- a/Course 1 - Part 6 - Lesson 2 - Notebook.ipynb
+++ b/Course 1 - Part 6 - Lesson 2 - Notebook.ipynb
@@ -256,7 +256,7 @@
         "3. The activation function to use -- in this case we'll use relu, which you might recall is the equivalent of returning x when x>0, else returning 0\n",
         "4. In the first layer, the shape of the input data.\n",
         "\n",
-        "You'll follow the Convolution with a MaxPooling layer which is then designed to compress the image, while maintaining the content of the features that were highlighted by the convlution. By specifying (2,2) for the MaxPooling, the effect is to quarter the size of the image. Without going into too much detail here, the idea is that it creates a 2x2 array of pixels, and picks the biggest one, thus turning 4 pixels into 1. It repeats this across the image, and in so doing halves the number of horizontal, and halves the number of vertical pixels, effectively reducing the image by 25%.\n",
+        "You'll follow the Convolution with a MaxPooling layer which is then designed to compress the image, while maintaining the content of the features that were highlighted by the convlution. By specifying (2,2) for the MaxPooling, the effect is to quarter the size of the image. Without going into too much detail here, the idea is that it creates a 2x2 array of pixels, and picks the biggest one, thus turning 4 pixels into 1. It repeats this across the image, and in so doing halves the number of horizontal, and halves the number of vertical pixels, effectively reducing the image by 75%.\n",
         "\n",
         "You can call model.summary() to see the size and shape of the network, and you'll notice that after every MaxPooling layer, the image size is reduced in this way. \n",
         "\n",


### PR DESCRIPTION
Halving both vertical and horizontal pixels effectively reduces the image by 75%, not 25%.