### PR TITLE
PiCamera framerate fixed on lower value

### DIFF
--- a/TensorFlow Deployment/Course 2 - TensorFlow Lite/Week 4/Examples/object_detection/main.py
+++ b/TensorFlow Deployment/Course 2 - TensorFlow Lite/Week 4/Examples/object_detection/main.py
@@ -53,6 +53,7 @@ if __name__ == '__main__':
 
     with picamera.PiCamera() as camera:
         camera.resolution = (640, 480)
+        camera.framerate=10
         while True:
             stream = np.empty((480, 640, 3), dtype=np.uint8)
             camera.capture(stream, 'rgb')


### PR DESCRIPTION
When default framerate was used, following exception occured (at least when using Raspberrry HQ camera 1.0):

picamera.exc.PiCameraRuntimeError: No data recevied from sensor. Check all connections, including the SUNNY chip on the camera board

With framerate set to 10 or lower, it works.