### PR TITLE
Documentation Typo Fix

### DIFF
--- a/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
+++ b/Course 1 - Part 4 - Lesson 2 - Notebook.ipynb
@@ -386,7 +386,7 @@
         "\n",
         "The output of the model is a list of 10 numbers. These numbers are a probability that the value being classified is the corresponding value (https://github.com/zalandoresearch/fashion-mnist#labels), i.e. the first value in the list is the probability that the image is of a '0' (T-shirt/top), the next is a '1' (Trouser) etc. Notice that they are all VERY LOW probabilities.\n",
         "\n",
-        "For the 9 (Ankle boot), the probability was in the 90's, i.e. the neural network is telling us that it's almost certainly a 7."
+        "For the last value (9th index), the probability was in the 90's. i.e. the neural network is telling us that it's almost certainly an Ankle boot with the corresponding label 9."
       ]
     },
     {


### PR DESCRIPTION
I noticed that the documentation seems a bit confusing and has a number 7 that doesn't need to be there.

Original: ~~For the 9 (Ankle boot)~~, the probability was in the 90's, i.e. the neural network is telling us that it's almost certainly ~~a 7~~.

Suggested Fix: **For the last value (9th index)**, the probability was in the 90's. i.e. the neural network is telling us that it's almost certainly **an Ankle boot with a corresponding label 9**.
Another Fix: **For the last value (9th index)**, the probability was in the 90's. i.e. the neural network is telling us that it's almost certainly **an Ankle boot.**
Side note: I think it is important to emphasize the correlation between the index position and label