### PR TITLE
fixed tfds.load() error when using tensorflow 2.2

### DIFF
--- a/TensorFlow Deployment/Course 2 - TensorFlow Lite/Week 1/Examples/TFLite_Week1_Transfer_Learning.ipynb
+++ b/TensorFlow Deployment/Course 2 - TensorFlow Lite/Week 1/Examples/TFLite_Week1_Transfer_Learning.ipynb
@@ -1,6 +1,6 @@
 {
   "cells": [
-  {
+    {
       "cell_type": "code",
       "metadata": {
         "id": "zX4Kg8DUTKWO",
@@ -213,9 +213,12 @@
       },
       "outputs": [],
       "source": [
-        "splits = tfds.Split.ALL.subsplit(weighted=(80, 10, 10))\n",
+        "# splits = tfds.Split.ALL.subsplit(weighted=(80, 10, 10))\n",
         "\n",
-        "splits, info = tfds.load('cats_vs_dogs', with_info=True, as_supervised=True, split = splits)\n",
+        "# splits, info = tfds.load('cats_vs_dogs', with_info=True, as_supervised=True, split = splits)\n",
+        "\n",
+        "# the tfds.load() above throws an error with TensorFlow 2.2\n",
+        "splits, info = tfds.load('cats_vs_dogs', with_info=True, as_supervised=True, split=['train[:80%]', 'train[80%:90%]', 'train[90%:100%]'])\n",
         "\n",
         "(train_examples, validation_examples, test_examples) = splits\n",
         "\n",


### PR DESCRIPTION
This change fixes the following error, when running on TensorFlow 2.2.0.

```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-4-852afec717c3> in <module>()
      1 splits = tfds.Split.ALL.subsplit(weighted=(80, 10, 10))
      2 
----> 3 splits, info = tfds.load('cats_vs_dogs', with_info=True, as_supervised=True, split = splits)
      4 
      5 (train_examples, validation_examples, test_examples) = splits

15 frames
/usr/local/lib/python3.6/dist-packages/tensorflow_datasets/core/tfrecords_reader.py in _str_to_relative_instruction(spec)
    354   res = _SUB_SPEC_RE.match(spec)
    355   if not res:
--> 356     raise AssertionError('Unrecognized instruction format: %s' % spec)
    357   unit = '%' if res.group('from_pct') or res.group('to_pct') else 'abs'
    358   return ReadInstruction(

AssertionError: Unrecognized instruction format: NamedSplitAll()(tfds.percent[0:80])
```