### PR TITLE
Fix typo for TensorFlow 2.x

### DIFF
--- a/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Question.ipynb
+++ b/TensorFlow In Practice/Course 3 - NLP/Course 3 - Week 2 - Exercise - Question.ipynb
@@ -306,7 +306,7 @@
         "  plt.legend([string, 'val_'+string])\n",
         "  plt.show()\n",
         "  \n",
-        "plot_graphs(history, \"acc\")\n",
+        "plot_graphs(history, \"accuracy\")\n",
         "plot_graphs(history, \"loss\")"
       ]
     },


### PR DESCRIPTION
`history` data contains `accuracy` keys, not `acc`.
The [answer](https://github.com/lmoroney/dlaicourse/blob/master/TensorFlow%20In%20Practice/Course%203%20-%20NLP/Course%203%20-%20Week%202%20-%20Exercise%20-%20Answer.ipynb) is correct.