### PR TITLE
Fix tfvis acc metrics

### DIFF
--- a/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 2/Examples/script.js
+++ b/TensorFlow Deployment/Course 1 - TensorFlow-JS/Week 2/Examples/script.js
@@ -21,7 +21,7 @@ function getModel() {
 }
 
 async function train(model, data) {
-	const metrics = ['loss', 'val_loss', 'accuracy', 'val_accuracy'];
+	const metrics = ['loss', 'val_loss', 'acc', 'val_acc'];
 	const container = { name: 'Model Training', styles: { height: '640px' } };
 	const fitCallbacks = tfvis.show.fitCallbacks(container, metrics);
   


### PR DESCRIPTION
The accuracy metrics should be called "acc" and "val_acc" instead of "accuracy" and "val_accuracy".