### PR TITLE
Fixed wrong filter number in conv2d in explanation

### DIFF
--- a/Course 1 - Part 6 - Lesson 2 - Notebook.ipynb
+++ b/Course 1 - Part 6 - Lesson 2 - Notebook.ipynb
@@ -263,7 +263,7 @@
         "\n",
         "```\n",
         "model = tf.keras.models.Sequential([\n",
-        "  tf.keras.layers.Conv2D(32, (3,3), activation='relu', input_shape=(28, 28, 1)),\n",
+        "  tf.keras.layers.Conv2D(64, (3,3), activation='relu', input_shape=(28, 28, 1)),\n",
         "  tf.keras.layers.MaxPooling2D(2, 2),\n",
         "```\n"
       ]


### PR DESCRIPTION
When you describe the code, `model=....` its filter number is from the actual code. 