### PR TITLE
use `utils` instead of `preprocessing` in parts

### DIFF
--- a/Horse_or_Human_NoValidation.ipynb
+++ b/Horse_or_Human_NoValidation.ipynb
@@ -506,7 +506,7 @@
       "source": [
         "import numpy as np\n",
         "from google.colab import files\n",
-        "from keras.preprocessing import image\n",
+        "from keras.utils import load_img, img_to_array\n",
         "\n",
         "uploaded = files.upload()\n",
         "\n",
@@ -514,8 +514,8 @@
         " \n",
         "  # predicting images\n",
         "  path = '/content/' + fn\n",
-        "  img = image.load_img(path, target_size=(300, 300))\n",
-        "  x = image.img_to_array(img)\n",
+        "  img = load_img(path, target_size=(300, 300))\n",
+        "  x = img_to_array(img)\n",
         "  x = np.expand_dims(x, axis=0)\n",
         "\n",
         "  images = np.vstack([x])\n",
@@ -554,7 +554,7 @@
       "source": [
         "import numpy as np\n",
         "import random\n",
-        "from tensorflow.keras.preprocessing.image import img_to_array, load_img\n",
+        "from tensorflow.keras.utils import img_to_array, load_img\n",
         "\n",
         "# Let's define a new Model that will take an image as input, and will output\n",
         "# intermediate representations for all layers in the previous model after\n",


### PR DESCRIPTION
The `tf.keras.preprocessing` APIs are depecated[^1]. I propose that `utils` be used.

[^1]: https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing